### PR TITLE
Add process_count.sh plugin, and minor tweak to netstat command in any_connections.sh 

### DIFF
--- a/any_connections.sh
+++ b/any_connections.sh
@@ -16,8 +16,8 @@ if [ $# -ne 1 ]; then
 fi
 
 PORT=$1
-NOW=`netstat -an |grep :$PORT`;
-SIMULTANEOUS=`echo "$NOW" |grep -c :$PORT`
+NOW=`netstat -an |grep :$PORT\ `;
+SIMULTANEOUS=`echo "$NOW" |grep -c :$PORT\ `
 ACTIVE=`echo "$NOW" |grep -c ESTABLISHED`
 IDLE=`echo "$NOW" |grep -c TIME_WAIT`
 CLOSING=`echo "$NOW" |grep -c FIN`

--- a/any_connections.sh
+++ b/any_connections.sh
@@ -16,7 +16,7 @@ if [ $# -ne 1 ]; then
 fi
 
 PORT=$1
-NOW=`netstat -ano |grep :$PORT`;
+NOW=`netstat -an |grep :$PORT`;
 SIMULTANEOUS=`echo "$NOW" |grep -c :$PORT`
 ACTIVE=`echo "$NOW" |grep -c ESTABLISHED`
 IDLE=`echo "$NOW" |grep -c TIME_WAIT`

--- a/process_count.sh
+++ b/process_count.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# process_count.sh <process_name>
+# Cloudkick plugin to check if a named process is running and count number of
+# processes. The process name is matched as regex.
+
+# Copyright (C) 2010 by David E. Chen <dchen@alumni.cmu.edu>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+if [ $# -ne 1 ]; then
+  echo -e "usage: `basename $0` <process_name>"
+  exit 1
+fi
+
+PS_COUNT=`ps -Ao command | grep -ve grep -e process_count.sh | grep -ce $1`
+
+if [ "$PS_COUNT" -lt "1" ]; then
+  echo "status err $1 has 0 processes"
+else
+  echo "status ok $1 has $PS_COUNT processes"
+  echo "metric process_count_$1 int $PS_COUNT"
+fi


### PR DESCRIPTION
process_count.sh (new):
Check if a process by name (given as an argument, can be regex) is running, and if so, returns a metric of how many matching processes are running.

any_connections.sh:
1. The netstat command was calling an extra -o flag, which displays timers that are unused by the plugin. Removing the flag speeds up the command by 50% in a few tests.
2. Fixed bug where specifying port 80 would return all ports that start with 80 such as 8000, 8080, etc.
