### PR TITLE
pidfileIsRunning script

### DIFF
--- a/pidfileIsRunning/_pidstatMetrics
+++ b/pidfileIsRunning/_pidstatMetrics
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+import sys, subprocess
+
+## This requires sysstat package for the pidstat command
+## You can add -s to the command if you have 9.1 for stack info
+IGNORED_FIELDS = ['Time','PID','%guest','CPU','Command']
+PIDSTAT_CMD = '/usr/bin/pidstat -p %s -druh'
+
+if len(sys.argv) != 2:
+  print "Usage: %s <pid>" % sys.argv[0]
+  sys.exit(0)
+
+devnullr = open('/dev/null', 'r')
+devnullw = open('/dev/null', 'w')
+cmd = PIDSTAT_CMD % sys.argv[1]
+p = subprocess.Popen(cmd.split(), stdin=devnullr, stderr=devnullw, stdout=subprocess.PIPE)
+
+lines = p.stdout.readlines()
+p.wait()
+
+metrics = []
+values = []
+found = False
+for l in lines:
+  if not found:
+    if not l.startswith('#'):
+      continue
+    found = True
+    metrics = l.split()[1:]
+  else:
+    values = l.split()
+
+if len(metrics) != len(values):    
+  sys.exit(0) # Ah crap!
+
+for i in range(len(metrics)):
+  if metrics[i] in IGNORED_FIELDS: continue
+  try:
+    int(values[i])
+    type = 'int'
+  except ValueError:
+    type = 'float'
+  print ' '.join(['metric', metrics[i], type, values[i]])
+
+

--- a/pidfileIsRunning/pidfileIsRunning
+++ b/pidfileIsRunning/pidfileIsRunning
@@ -1,0 +1,34 @@
+#!/bin/bash
+if [ $# -ne 2 ]
+then
+  echo "This should be called from cloudkick agent:"
+  echo "  $0 <name> <pidfile>"
+  exit 1
+fi
+NAME=$1
+PIDFILE=$2
+
+## Checks whether pid is running. Also outputs basic process stats as metrics
+if ! [ -e "$PIDFILE" ]
+then
+  RUNNING=false
+else
+  PID="$(cat $PIDFILE)"
+  if [ -n "$PID" ]  && [ -d "/proc/$PID" ]
+  then
+    RUNNING=true
+  else
+    RUNNING=false
+  fi
+fi
+
+if [ "$RUNNING" = "true" ]
+then
+  echo "status ok $NAME is running"
+  # Ok, now get metrics
+  PID=$(cat $PIDFILE 2>/dev/null)
+  $(dirname $0)/_pidstatMetrics $PID 
+
+else
+  echo "status err $NAME is not running"
+fi


### PR DESCRIPTION
Custom plugin to pass a pidfile and error if the pid isnt running.  Calls a separate script to collect metrics on the pid from pidstat (part of sysstat utils)
