### PR TITLE
minor whitespace fix to postfix_status.rb

### DIFF
--- a/postfix_status.rb
+++ b/postfix_status.rb
@@ -14,7 +14,7 @@
 postqueue=`which postqueue`.chomp
 
 running=`ps axf |grep postfix |grep -v grep`.chomp
-if ( running =~ /^(\d+)\s+(pts|tty|\?)/ )
+if ( running =~ /^\s*(\d+)\s+(pts|tty|\?)/ )
 	pid=$1
 	messages=`#{postqueue} -p |grep -v "Mail queue is empty" |wc -l`.chomp.to_i
 	if ( messages > 0 )


### PR DESCRIPTION
this script was failing on our system because there's whitespace before the PID in the ps output. 
