### PR TITLE
cyberpower_status.py

### DIFF
--- a/cyberpower_status.py
+++ b/cyberpower_status.py
@@ -36,11 +36,10 @@ def getInfo():
    # Ensure pwrstat is present. If not, abort.
    status, out = commands.getstatusoutput('pwrstat -status')
    if status:
-       msg = "Unable to find PowerPanel software.\n"
+       msg = "status err Unable to find PowerPanel software.\n"
        msg += "Please install the required software and try again.\n"
-       msg += status
        sys.stderr.write(msg)
-       sys.exit(1)
+       sys.exit(status)
 
    # Build our results into key: value pairs.
    results = {}
@@ -88,7 +87,7 @@ def makeMetric(ourName, ourValue, gauge=False):
 
     # Check if it's a string, int or float.
     if ourType not in ( str, int, float ):
-        msg = 'Invalid value passed to makeMetric. Exiting.\n'
+        msg = 'status err Invalid value passed to makeMetric. Exiting.\n'
         sys.stderr.write(msg)
         sys.exit(1)
 
@@ -111,7 +110,7 @@ def makeMetric(ourName, ourValue, gauge=False):
 if __name__ == '__main__':
     # pwrstat requires root to poll UPS
     if os.getuid():
-        msg = 'This script must be run as root.\n'
+        msg = 'status err This script must be run as root.\n'
         sys.stderr.write(msg)
         sys.exit(1)
 

--- a/cyberpower_status.py
+++ b/cyberpower_status.py
@@ -36,11 +36,15 @@ def getInfo():
                option = 'Rating Wattage'
            elif option == 'Battery Capacity':
                option = 'Battery Percentage'
+           elif option == 'Remaining Runtime':
+               option = 'Minutes Remaining'
+               # A period after "Min" requires a different split
+               value = int(line.split('.')[-2].strip().split()[0])
 
            # Pull the options we want as integers.
            if option in ( 'Rating Wattage', 'Battery Percentage',
                           'Utility Voltage', 'Output Voltage', 
-                          'Rating Voltage', 'Load Wattage' ):
+                          'Rating Voltage', 'Load Wattage', ):
                value = int(value.split()[0])
 
            # Add our new key

--- a/cyberpower_status.py
+++ b/cyberpower_status.py
@@ -8,6 +8,8 @@ def getInfo():
    """
    Get all pertinent information from our CyberPower UPS
    """
+   
+   # Ensure pwrstat is present. If not, abort.
    status, out = commands.getstatusoutput('pwrstat -status')
    if status is not 0:
        msg = "Unable to find PowerPanel software.\n"
@@ -16,12 +18,15 @@ def getInfo():
        sys.stderr.write(msg)
        sys.exit(1)
 
+   # Build our results into key: value pairs.
    results = {}
+   # All values are separated by a line of periods. Get the items on either side.
    for line in out.split('\n'):
        if '.' in line:
            option = line.split('.')[0].strip()
            value = line.split('.')[-1].strip()
-           # Rename the following options and pull our integers as well.
+           # Start setting our numbers as integers.
+           # Rename the following options as well.
            if option == 'Load':
                option = 'Load Wattage'
                value = int(value.split()[0]) 
@@ -33,7 +38,7 @@ def getInfo():
            elif option == 'Battery Capacity':
                option = 'Battery Percentage'
                value = int(value.split()[0])
-           # The rest are all much easier. =)
+           # The rest are all much easier. =) Int only.
            elif option == 'Utility Voltage':
                value = int(value.split()[0])
            elif option == 'Output Voltage':
@@ -41,8 +46,10 @@ def getInfo():
            elif option == 'Rating Voltage':
                value = int(value.split()[0])
 
+           # Add our new key
            results[option] = value
-   
+
+      # Send the results
    return results
 
 def makeMetric(ourName, ourValue, gauge=False):
@@ -51,54 +58,57 @@ def makeMetric(ourName, ourValue, gauge=False):
     https://support.cloudkick.com/Creating_a_plugin
     """
 
+    # Check if string, int or float.
     if type(ourValue) is str:
         ourType = 'string'
     elif type(ourValue) is int:
         ourType = 'int'
+        # If an int, see if we need this as a gauge.
         if gauge is True:
             ourType = 'gauge'
     elif type(ourValue) is float:
         ourType = 'float'
+    # If not a supported type, abort.
     else:
         msg = 'Invalid value passed to makeMetric. Exiting.\n'
         sys.stderr.write(msg)
         sys.exit(1)
 
+    # Cannot have spaces in our name, so replace_with_underscores.
     ourName = ourName.replace(' ', '_')
 
+    # Send our metric.
     return 'metric %s %s %s\n' % (ourName, ourType, ourValue)
 
-# Do the damn thing.
+# MAIN
 if __name__ == '__main__':
+    # pwrstat requires root to poll UPS
     if os.getuid() != 0:
         msg = 'This script must be run as root.\n'
         sys.stderr.write(msg)
         sys.exit(1)
 
+    # Get our info from the UPS
     info = getInfo()
+    # If we have the info, check it's state
     if info:
         if info['State'] == 'Normal':
-            state = 'ok'
+            status = 'ok'
         else:
-            state = 'warn'
+            status = 'warn'
 
-        # First our status message
-        msg = "status %s Our %s UPS is in a '%s' state.\n" % (state, info['Model Name'], info['State'])
-        # Then, metrics.
-        # First, metrics where we rename the value
-        #msg += makeMetric('Load Wattage',  info['Load Wattage'])
-        #msg += makeMetric('Rating Wattage',  info['Rating Wattage'])
-        #msg += makeMetric('Battery Percentage', info['Battery Percentage'])
-        # And lastly, the boring ones.
-
-        # Maybe we should iterate like this:
-        for key, value in info.items():
-            msg += makeMetric(key, value)
-        # And have makeMetric decide if it's an int, float or a string.
+        # First, build our status message based on state.
+        msg = "status %s Our %s UPS is in a '%s' state.\n" % (status, info['Model Name'], info['State'])
+        
+        # Then, iterate through our keys
+        for k, v in info.items():
+            msg += makeMetric(k, v)
 
         # Send it all to stdout and we are done.
         sys.stdout.write(msg)
         sys.exit(0)
-    else:
-        print 'something went wrong.'
 
+    # If we got here, something went wrong.
+    else:
+        sys.stdout.write('status err Unable to get our UPS information.\n')
+        sys.exit(1)

--- a/cyberpower_status.py
+++ b/cyberpower_status.py
@@ -20,12 +20,14 @@ def getInfo():
 
    # Build our results into key: value pairs.
    results = {}
-   # All values are separated by a line of periods. Get the items on either side.
+   # All values are separated by a line of periods.
+   # Get the items on either side.
    for line in out.split('\n'):
        if '.' in line:
            option = line.split('.')[0].strip()
            value = line.split('.')[-1].strip()
            # Rename a few options to make them more clear.
+           # Also, in making numbers ints, we lose the Volt/Watt label.
            if option == 'Load':
                option = 'Load Wattage'
                 # Might as well pull out the percentage while we are here.
@@ -44,7 +46,7 @@ def getInfo():
            # Add our new key
            results[option] = value
 
-      # Send the results
+   # Send the results
    return results
 
 def makeMetric(ourName, ourValue, gauge=False):
@@ -53,14 +55,16 @@ def makeMetric(ourName, ourValue, gauge=False):
     https://support.cloudkick.com/Creating_a_plugin
     """
 
+    # Find our type
     ourType = type(ourValue)
 
-    # Check if string, int or float.
+    # Check if it's a string, int or float.
     if ourType not in ( str, int, float ):
         msg = 'Invalid value passed to makeMetric. Exiting.\n'
         sys.stderr.write(msg)
         sys.exit(1)
 
+    # Set to gauge if needed, otherwise change our object to it's name.
     if gauge and ourType is int:
         ourType = 'gauge'
     else:
@@ -90,7 +94,9 @@ if __name__ == '__main__':
             status = 'warn'
 
         # First, build our status message based on state.
-        msg = "status %s Our %s UPS is in a '%s' state.\n" % (status, info['Model Name'], info['State'])
+        msg = "status %s Our %s UPS is in a '%s' state.\n" % (status, 
+                                                              info['Model Name'],
+                                                              info['State'])
         
         # Then, iterate through our keys
         for k, v in info.items():

--- a/cyberpower_status.py
+++ b/cyberpower_status.py
@@ -44,7 +44,7 @@ def getInfo():
            # Pull the options we want as integers.
            if option in ( 'Rating Wattage', 'Battery Percentage',
                           'Utility Voltage', 'Output Voltage', 
-                          'Rating Voltage', 'Load Wattage', ):
+                          'Rating Voltage', 'Load Wattage' ):
                value = int(value.split()[0])
 
            # Add our new key

--- a/cyberpower_status.py
+++ b/cyberpower_status.py
@@ -1,4 +1,28 @@
 #!/usr/bin/python -tt
+# cyberpower_status.py
+#
+# Builds metrics provided to us by the PowerPanel package (pwrstat)
+# for CyberPower UPS units.
+#
+# Written for the CP850PFCLCD using version 1.2 of PowerPanel for Linux, 
+# it should function the same for any CyberPower UPS unit that supports
+# communications over USB. If you run into any bugs, let me know.
+#
+# Copyright (C) 2011  James Bair <james.d.bair@gmail.com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 import commands
 import os

--- a/cyberpower_status.py
+++ b/cyberpower_status.py
@@ -71,6 +71,9 @@ def makeMetric(ourName, ourValue, gauge=False):
     # Set to gauge if needed, otherwise change our object to it's name.
     if gauge and ourType is int:
         ourType = 'gauge'
+    # CloudKick wants string instead of str
+    elif ourType is str:
+        ourType = 'string'
     else:
         ourType = ourType.__name__
 

--- a/cyberpower_status.py
+++ b/cyberpower_status.py
@@ -1,0 +1,104 @@
+#!/usr/bin/python -tt
+
+import commands
+import os
+import sys
+
+def getInfo():
+   """
+   Get all pertinent information from our CyberPower UPS
+   """
+   status, out = commands.getstatusoutput('pwrstat -status')
+   if status is not 0:
+       msg = "Unable to find PowerPanel software.\n"
+       msg += "Please install the required software and try again.\n"
+       msg += status
+       sys.stderr.write(msg)
+       sys.exit(1)
+
+   results = {}
+   for line in out.split('\n'):
+       if '.' in line:
+           option = line.split('.')[0].strip()
+           value = line.split('.')[-1].strip()
+           # Rename the following options and pull our integers as well.
+           if option == 'Load':
+               option = 'Load Wattage'
+               value = int(value.split()[0]) 
+                # Might as well pull out the percentage while we are here.
+               results['Watt Percentage'] = int(line.split()[-2].split('(')[1])
+           elif option == 'Rating Power':
+               option = 'Rating Wattage'
+               value = int(value.split()[0])
+           elif option == 'Battery Capacity':
+               option = 'Battery Percentage'
+               value = int(value.split()[0])
+           # The rest are all much easier. =)
+           elif option == 'Utility Voltage':
+               value = int(value.split()[0])
+           elif option == 'Output Voltage':
+               value = int(value.split()[0])
+           elif option == 'Rating Voltage':
+               value = int(value.split()[0])
+
+           results[option] = value
+   
+   return results
+
+def makeMetric(ourName, ourValue, gauge=False):
+    """
+    Build a metric string per the documentation here:
+    https://support.cloudkick.com/Creating_a_plugin
+    """
+
+    if type(ourValue) is str:
+        ourType = 'string'
+    elif type(ourValue) is int:
+        ourType = 'int'
+        if gauge is True:
+            ourType = 'gauge'
+    elif type(ourValue) is float:
+        ourType = 'float'
+    else:
+        msg = 'Invalid value passed to makeMetric. Exiting.\n'
+        sys.stderr.write(msg)
+        sys.exit(1)
+
+    ourName = ourName.replace(' ', '_')
+
+    return 'metric %s %s %s\n' % (ourName, ourType, ourValue)
+
+# Do the damn thing.
+if __name__ == '__main__':
+    if os.getuid() != 0:
+        msg = 'This script must be run as root.\n'
+        sys.stderr.write(msg)
+        sys.exit(1)
+
+    info = getInfo()
+    if info:
+        if info['State'] == 'Normal':
+            state = 'ok'
+        else:
+            state = 'warn'
+
+        # First our status message
+        msg = "status %s Our %s UPS is in a '%s' state.\n" % (state, info['Model Name'], info['State'])
+        # Then, metrics.
+        # First, metrics where we rename the value
+        #msg += makeMetric('Load Wattage',  info['Load Wattage'])
+        #msg += makeMetric('Rating Wattage',  info['Rating Wattage'])
+        #msg += makeMetric('Battery Percentage', info['Battery Percentage'])
+        # And lastly, the boring ones.
+
+        # Maybe we should iterate like this:
+        for key, value in info.items():
+            msg += makeMetric(key, value)
+        # And have makeMetric decide if it's an int, float or a string.
+
+        # Send it all to stdout and we are done.
+        sys.stdout.write(msg)
+        sys.exit(0)
+    else:
+        print 'something went wrong.'
+

--- a/mdadm_check.py
+++ b/mdadm_check.py
@@ -1,0 +1,196 @@
+#!/usr/bin/python
+# CloudKick Plugin to check the status of any
+# mdadm devices on a server.
+#
+# Copyright (C) 2011 James Bair <james.d.bair@gmail.com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+import commands
+import os
+import re
+import stat
+import sys
+
+def systemCommand(command):
+    """
+    Wrapper for executing a system command. Reports error to CloudKick
+    as well as to standard error.
+    """
+
+    commStatus, commOut = commands.getstatusoutput(command)
+    # If our command fails, abort entirely and notify CloudKick
+    if commStatus != 0:
+        sys.stderr.write('Error: Failure when executing the following ')
+        sys.stderr.write("command: '%s'\n" % (command,))
+        sys.stderr.write("Exit status: %d\n" % (commStatus,))
+        sys.stderr.write("Output: %s\n\n" % (commOut,))
+        sys.stderr.write('status err System command failure: ')
+        sys.stderr.write('%s\n' % (command,))
+        sys.exit(1)
+    # If we get a 0 exit code, all is well. Return the data.
+    else:
+        return commOut
+
+def which(program):
+    """
+    Used to find a program in the system's PATH
+    Shamelessly borrowed from stackoverflow here:
+    http://stackoverflow.com/questions/377017/test-if-executable-exists-in-python
+    """
+
+    def is_exe(fpath):
+        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+    fpath, fname = os.path.split(program)
+    if fpath:
+        if is_exe(program):
+            return program
+    else:
+        for path in os.environ["PATH"].split(os.pathsep):
+            exe_file = os.path.join(path, program)
+            if is_exe(exe_file):
+                return exe_file
+
+    return None
+
+def findMdDevices():
+    """
+    Finds all /dev/md* devices on the system.
+    """
+
+    results = []
+    devPath = '/dev/'
+    validation = devPath + 'md'
+    for device in os.listdir(devPath):
+        fullPath = devPath + device
+        if validation not in fullPath:
+            continue
+        mode = os.stat(fullPath).st_mode
+        if stat.S_ISBLK(mode):
+            results.append(fullPath)
+
+    # In case we have no /dev/md* devices
+    if results == []:
+        results = None
+
+    return results
+
+def makeMetric(ourName, ourValue, gauge=False):
+    """
+    Build a metric string per the documentation here:
+    https://support.cloudkick.com/Creating_a_plugin
+    """
+
+    # Find our type
+    ourType = type(ourValue)
+
+    # Check if it's a string, int or float.
+    if ourType not in ( str, int, float ):
+        msg = 'status err Invalid value passed to makeMetric. Exiting.\n'
+        sys.stderr.write(msg)
+        sys.exit(1)
+
+    # Set to gauge if needed, otherwise change our object to it's name.
+    if gauge and ourType is int:
+        ourType = 'gauge'
+    # CloudKick wants string instead of str
+    elif ourType is str:
+        ourType = 'string'
+    else:
+        ourType = ourType.__name__
+
+    # Cannot have spaces in our name, so replace_with_underscores.
+    ourName = ourName.replace(' ', '_')
+
+    # Send our metric.
+    return 'metric %s %s %s\n' % (ourName, ourType, ourValue)
+
+
+def main():
+    """
+    Main function for mdadm_check.py
+    """
+
+    # Make sure mdadm is installed
+    prog = 'mdadm'
+    if not which(prog):
+        msg = 'status warn %s is not installed on this system.\n' % (prog,)
+        sys.stdout.write(msg)
+        sys.exit(0)
+
+    # Find our devices; exit if none found.
+    devices = findMdDevices()
+    if not devices:
+        msg = 'status warn No mdadm devices found on this system.\n'
+        sys.stdout.write(msg)
+        sys.exit(0)
+
+    # Used in reporting
+    devNum = len(devices)
+
+    # Create a dict for each device
+    comp = re.compile('^\s+(\w+\s*\w*)\s+\:\s+(.*)\s*$', re.MULTILINE)
+    devStats = {}
+    safeStates = ( 'clean', 'active' )
+    for device in devices:
+        raidInfo = systemCommand('mdadm --detail %s' % (device,))
+        results = dict(comp.findall(raidInfo))
+
+        # I have no idea why, but state holds a trailing space.
+        # I just strip them all. Equality for all states!
+        # Also, while we are here, we try to change them from
+        # a string over to a int or a float.
+        for result in results:
+            results[result] = results[result].strip()
+            # Try an integer first
+            try:
+                results[result] = int(results[result])
+            except:
+                # Then try floating point
+                try:
+                    results[result] = float(results[result])
+                except:
+                    pass
+        # Check for failed arrays
+        state = results['State']
+        if state not in safeStates:
+            msg = "status warn Array %s is in a '%s' state.\n" % (device, state) 
+            sys.stdout.write(msg)
+            sys.exit(1)
+        devStats[device] = results
+
+    # It's the little things.
+    if devNum == 1:
+        devStr = 'device'
+    else:
+        devStr = 'devices'
+
+    # Build our metrics
+    msg = ''
+    for device in devStats:    
+        devName = device.split('/')[-1] + '_'
+        for stat in devStats[device]: 
+            ourName = devName + stat
+            ourValue = devStats[device][stat]
+            msg += makeMetric(ourName, ourValue)
+
+    # Send the all clear
+    msg += "status ok Verified the following %d %s in a clean state: %s\n" % (devNum, devStr, ' '.join(devices))
+    sys.stdout.write(msg)
+    sys.exit(0)
+
+if __name__ == '__main__':
+    main()

--- a/users_logged_in.py
+++ b/users_logged_in.py
@@ -112,7 +112,7 @@ def main():
 
         # Build our users logged in message.
         userMsg = "%d %s logged in: " % (userNum, userWord)
-        userMsg = userMsg + ", ".join(users)
+        userMsg += ", ".join(users)
 
         # Plugin spec limits status string to 48 chars.
         #


### PR DESCRIPTION
Wrote a plugin to monitor and build metrics for the information provided by the CyberPower UPS family. Used my specific setup as an example, but it should work for all units. Here are the example inputs and the output it provides:
# pwrstat -status

The UPS information shows as following:

```
Properties:
    Model Name................... CP850PFCLCD
    Firmware Number.............. CRDA103-461
    Rating Voltage............... 120 V
    Rating Power................. 510 Watt

Current UPS status:
    State........................ Normal
    Power Supply by.............. Utility Power
    Utility Voltage.............. 123 V
    Output Voltage............... 123 V
    Battery Capacity............. 100 %
    Remaining Runtime............ 21 min.
    Load......................... 122 Watt(24 %)
    Line Interaction............. None
    Test Result.................. Passed at 2011/09/28 18:16:09
    Last Power Event............. None
```
# /usr/lib/cloudkick-agent/plugins/cyberpower_status.py

status ok Our CP850PFCLCD UPS is in a 'Normal' state.
metric Firmware_Number string CRDA103-461
metric Last_Power_Event string None
metric Utility_Voltage int 123
metric Battery_Percentage int 100
metric Rating_Voltage int 120
metric Line_Interaction string None
metric Minutes_Remaining int 21
metric Rating_Wattage int 510
metric State string Normal
metric Output_Voltage int 123
metric Load_Wattage int 122
metric Model_Name string CP850PFCLCD
metric Watt_Percentage int 24
metric Test_Result string Passed at 2011/09/28 18:16:09
metric Power_Supply_by string Utility Power
