### PR TITLE
Return size of postqueue  in the postfix_status.rb plugin.

### DIFF
--- a/postfix_status.rb
+++ b/postfix_status.rb
@@ -19,6 +19,7 @@ if ( running =~ /^\s*(\d+)\s+(pts|tty|\?)/ )
 	messages=`#{postqueue} -p |grep -v "Mail queue is empty" |wc -l`.chomp.to_i
 	if ( messages > 0 )
 		puts "status warn #{messages} messages in the postfix queue"
+		puts "metric postfix_queue_size int #{messages}"
 	else
 		puts "status ok postfix running on pid #{pid} with no pending messages"
 	end

--- a/postfix_status.rb
+++ b/postfix_status.rb
@@ -22,6 +22,7 @@ if ( running =~ /^\s*(\d+)\s+(pts|tty|\?)/ )
 		puts "metric postfix_queue_size int #{messages}"
 	else
 		puts "status ok postfix running on pid #{pid} with no pending messages"
+		puts "metric postfix_queue_size int #{messages}"
 	end
 else
 	puts "status critical postfix not running!"


### PR DESCRIPTION
It seems logical that since this plugin is checking for the # of messages in the postfix queue that we make it a graph-able as well.
